### PR TITLE
Use `/usr/bin/env bash` instead of `/bin/bash`

### DIFF
--- a/etc/scripts/catalog.sh
+++ b/etc/scripts/catalog.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 DIR=$(cd $(dirname "$0")/../../olm-catalog && pwd)
 

--- a/etc/scripts/install.sh
+++ b/etc/scripts/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Installs istio, OLM and all knative operators on minishift
 

--- a/etc/scripts/prep-knative.sh
+++ b/etc/scripts/prep-knative.sh
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/usr/bin/env bash 
 
 set -x
 


### PR DESCRIPTION
Some systems may not have /bin/bash (NixOS for example)… Using
/usr/bin/env bash has the benefit of looking for whatever the
default version of the program is in your current environment.

Signed-off-by: Vincent Demeester <vincent@sbr.pm>