### PR TITLE
WIP: Adding Kafka/Strimzi

### DIFF
--- a/etc/scripts/install.sh
+++ b/etc/scripts/install.sh
@@ -56,6 +56,9 @@ minishift start
 eval "$(minishift oc-env)"
 "$DIR/prep-knative.sh"
 
+# For Eventing-Kafka, we need Strimzi
+"$DIR/prep-strimzi.sh"
+
 # istio
 git clone https://github.com/minishift/minishift-addons "$REPO_DIR/minishift-addons"
 minishift addon install "$REPO_DIR/minishift-addons/add-ons/istio"

--- a/etc/scripts/prep-strimzi.sh
+++ b/etc/scripts/prep-strimzi.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash 
+
+set -x
+
+# Install the Apache Kafka Operator and CRDs from the Strimzi project
+oc apply -f https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.8.2/strimzi-cluster-operator-0.8.2.yaml
+# Apply a simple cluster with one ZK and one Kafka node
+oc apply -f https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/examples/kafka/kafka-persistent-single.yaml

--- a/etc/upstream/knative-eventing-kafka-0.2.1.yaml
+++ b/etc/upstream/knative-eventing-kafka-0.2.1.yaml
@@ -1,0 +1,174 @@
+---
+apiVersion: eventing.knative.dev/v1alpha1
+kind: ClusterChannelProvisioner
+metadata:
+  name: kafka-channel
+spec: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kafka-channel-controller
+  namespace: knative-eventing
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kafka-channel-controller
+rules:
+- apiGroups:
+  - eventing.knative.dev
+  resources:
+  - channels
+  - clusterchannelprovisioners
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+- apiGroups:
+  - ""
+  resourceNames:
+  - kafka-channel-dispatcher
+  resources:
+  - configmaps
+  verbs:
+  - update
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - virtualservices
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kafka-channel-controller-manage
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kafka-channel-controller
+subjects:
+- kind: ServiceAccount
+  name: kafka-channel-controller
+  namespace: knative-eventing
+---
+apiVersion: v1
+data:
+  bootstrap_servers: my-cluster-kafka-bootstrap.myproject.svc.cluster.local:9092
+kind: ConfigMap
+metadata:
+  name: kafka-channel-controller-config
+  namespace: knative-eventing
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: kafka-channel-controller
+  namespace: knative-eventing
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: kafka-channel-controller
+    spec:
+      containers:
+      - image: gcr.io/knative-releases/github.com/knative/eventing/pkg/provisioners/kafka/cmd/controller@sha256:13b54db8c09e30319661a0c8cb750371fc5501b015cae36a9345c98f40f36e6e
+        name: kafka-channel-controller-controller
+        volumeMounts:
+        - mountPath: /etc/config-provisioner
+          name: kafka-channel-controller-config
+      serviceAccountName: kafka-channel-controller
+      volumes:
+      - configMap:
+          name: kafka-channel-controller-config
+        name: kafka-channel-controller-config
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kafka-channel-dispatcher
+  namespace: knative-eventing
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kafka-channel-dispatcher
+  namespace: knative-eventing
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kafka-channel-dispatcher
+  namespace: knative-eventing
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kafka-channel-dispatcher
+subjects:
+- kind: ServiceAccount
+  name: kafka-channel-dispatcher
+  namespace: knative-eventing
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: kafka-channel-dispatcher
+  namespace: knative-eventing
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      clusterChannelProvisioner: kafka-channel
+      role: dispatcher
+  serviceName: kafka-channel-dispatcher-service
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
+      labels:
+        clusterChannelProvisioner: kafka-channel
+        role: dispatcher
+    spec:
+      containers:
+      - env:
+        - name: DISPATCHER_CONFIGMAP_NAME
+          value: kafka-channel-dispatcher
+        - name: DISPATCHER_CONFIGMAP_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: gcr.io/knative-releases/github.com/knative/eventing/pkg/provisioners/kafka/cmd/dispatcher@sha256:ccfe7200b8661e2c2d5a6d0708dd1659440f195b82725e632305dbac715a35c1
+        name: dispatcher
+        volumeMounts:
+        - mountPath: /etc/config-provisioner
+          name: kafka-channel-controller-config
+      serviceAccountName: kafka-channel-dispatcher
+      volumes:
+      - configMap:
+          name: kafka-channel-controller-config
+        name: kafka-channel-controller-config


### PR DESCRIPTION
## Preparation of Strimzi

adding `prep-strimzi.sh` that installs a small/simple Apache Kafka cluster (which is needed for **Kafka channels**), and invoking this _after_ `prep-knative.sh`.

## Kafka yaml and the Operator

* adding upstream **NIGHTLY** (the final `v0.2.1` will be out soon) content;

> NOTE: There is no CRD for Kafka, and the controller/dispatcher is required to run inside the `knative-eventing` namespace, so I guess we don't need a `...package.yaml` file for Kafka.

However, one problem: the yaml contains a `statefulset`. I seem to recall that this is not yet supported by the Operator-SDK. Besides that, it's straightforward, and similar to the `in-memory-channel` bits, and has similar service accounts (like upstream `in-memory` component), so I think that ours will match them to `default` SA in the `clusterserviceversion.yaml` file.

I am not 100% sure what's the best approach, but I think we can add the "Kafka bits" to that `knative-eventing.v0.2.0.clusterserviceversion.yaml` (or we rename it to 0.2.1, once the new eventing release is out) if it is OK to go w/ `Statefulset`s ...

## Test drive and checking 

After the pimped `install.sh` is done, you can manually install it like:
```
## Eventing-Kafka
oc adm policy add-scc-to-user anyuid -z kafka-channel-dispatcher -n knative-eventing
oc adm policy add-scc-to-user anyuid -z kafka-channel-controller -n knative-eventing

## Ref. the Strimzi URLs
curl -L https://storage.googleapis.com/knative-releases/eventing/latest/kafka-channel.yaml \
  | sed 's/kafkabroker.kafka/my-cluster-kafka-bootstrap.myproject.svc.cluster.local/' \
  | oc apply -f -

oc adm policy add-cluster-role-to-user cluster-admin -z kafka-channel-dispatcher -n knative-eventing
oc adm policy add-cluster-role-to-user cluster-admin -z kafka-channel-controller -n knative-eventing

oc get pods -n knative-eventing -w 
```




