### PR TITLE
install.sh: preload some images

### DIFF
--- a/etc/scripts/install.sh
+++ b/etc/scripts/install.sh
@@ -129,5 +129,13 @@ oc -n knative-serving get cm config-controller -oyaml | sed "s/\(^ *registriesSk
 oc import-image -n openshift golang --from=centos/go-toolset-7-centos7 --confirm
 oc import-image -n openshift golang:1.11 --from=centos/go-toolset-7-centos7 --confirm
 
+eval "$(minishift docker-env)"
+docker image pull centos/go-toolset-7-centos7:latest
+docker image pull vdemeester/kobw-builder:0.1.1
+for img in $(oc get image.caching.internal.knative.dev -ojsonpath='{range .items[*]}{.spec.image}{"\n"}{end}' --all-namespaces)
+do
+    docker pull $img
+done
+
 # show all the pods
 oc get pods --all-namespaces


### PR DESCRIPTION
- the golang image used for demos
- the kobw-builder image used for demos
- any knative to-be-cached images

This should move the 1st build time really close (if not the same as) the next builds (aka ~10s)

cc @matzew @jcrossley3 @markusthoemmes 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>