### PR TITLE
More updates for OpenShift 4

### DIFF
--- a/etc/scripts/installation-functions.sh
+++ b/etc/scripts/installation-functions.sh
@@ -159,9 +159,6 @@ function install_istio {
 	metadata:
 	  name: istio-operator
 	  namespace: istio-operator
-	spec:
-	  targetNamespaces:
-	    - istio-operator
 	EOF
   fi
   cat <<-EOF | oc apply -f -
@@ -217,9 +214,6 @@ function install_knative_build {
 	metadata:
 	  name: knative-build
 	  namespace: knative-build
-	spec:
-	  targetNamespaces:
-	    - knative-build
 	EOF
   fi
   cat <<-EOF | oc apply -f -
@@ -246,9 +240,6 @@ function install_knative_serving {
 	metadata:
 	  name: knative-serving
 	  namespace: knative-serving
-	spec:
-	  targetNamespaces:
-	    - knative-serving
 	EOF
   fi
   cat <<-EOF | oc apply -f -
@@ -275,9 +266,6 @@ function install_knative_eventing {
 	metadata:
 	  name: knative-eventing
 	  namespace: knative-eventing
-	spec:
-	  targetNamespaces:
-	    - knative-eventing
 	EOF
   fi
   cat <<-EOF | oc apply -f -

--- a/etc/scripts/installation-functions.sh
+++ b/etc/scripts/installation-functions.sh
@@ -152,6 +152,18 @@ function install_olm {
 function install_istio {
   # istio
   oc create ns istio-operator
+  if check_operatorgroups; then
+    cat <<-EOF | oc apply -f -
+	apiVersion: operators.coreos.com/v1alpha2
+	kind: OperatorGroup
+	metadata:
+	  name: istio-operator
+	  namespace: istio-operator
+	spec:
+	  targetNamespaces:
+	    - istio-operator
+	EOF
+  fi
   cat <<-EOF | oc apply -f -
 	apiVersion: operators.coreos.com/v1alpha1
 	kind: Subscription
@@ -163,15 +175,6 @@ function install_istio {
 	  name: maistra
 	  source: maistra-operators
 	EOF
-  if check_operatorgroups; then
-    cat <<-EOF | oc apply -f -
-	apiVersion: operators.coreos.com/v1alpha2
-	kind: OperatorGroup
-	metadata:
-	  name: istio-operator
-	  namespace: istio-operator
-	EOF
-  fi
   wait_for_all_pods istio-operator
 
   cat <<-EOF | oc apply -f -
@@ -207,6 +210,18 @@ function install_istio {
 
 function install_knative_build {
   oc create ns knative-build
+  if check_operatorgroups; then
+    cat <<-EOF | oc apply -f -
+	apiVersion: operators.coreos.com/v1alpha2
+	kind: OperatorGroup
+	metadata:
+	  name: knative-build
+	  namespace: knative-build
+	spec:
+	  targetNamespaces:
+	    - knative-build
+	EOF
+  fi
   cat <<-EOF | oc apply -f -
 	apiVersion: operators.coreos.com/v1alpha1
 	kind: Subscription
@@ -220,19 +235,22 @@ function install_knative_build {
 	  startingCSV: knative-build.${KNATIVE_BUILD_VERSION}
 	  channel: alpha
 	EOF
+}
+
+function install_knative_serving {
+  oc create ns knative-serving
   if check_operatorgroups; then
     cat <<-EOF | oc apply -f -
 	apiVersion: operators.coreos.com/v1alpha2
 	kind: OperatorGroup
 	metadata:
-	  name: knative-build
-	  namespace: knative-build
+	  name: knative-serving
+	  namespace: knative-serving
+	spec:
+	  targetNamespaces:
+	    - knative-serving
 	EOF
   fi
-}
-
-function install_knative_serving {
-  oc create ns knative-serving
   cat <<-EOF | oc apply -f -
 	apiVersion: operators.coreos.com/v1alpha1
 	kind: Subscription
@@ -246,19 +264,22 @@ function install_knative_serving {
 	  startingCSV: knative-serving.${KNATIVE_SERVING_VERSION}
 	  channel: alpha
 	EOF
+}
+
+function install_knative_eventing {
+  oc create ns knative-eventing
   if check_operatorgroups; then
     cat <<-EOF | oc apply -f -
 	apiVersion: operators.coreos.com/v1alpha2
 	kind: OperatorGroup
 	metadata:
-	  name: knative-serving
-	  namespace: knative-serving
+	  name: knative-eventing
+	  namespace: knative-eventing
+	spec:
+	  targetNamespaces:
+	    - knative-eventing
 	EOF
   fi
-}
-
-function install_knative_eventing {
-  oc create ns knative-eventing
   cat <<-EOF | oc apply -f -
 	apiVersion: operators.coreos.com/v1alpha1
 	kind: Subscription
@@ -272,13 +293,4 @@ function install_knative_eventing {
 	  startingCSV: knative-eventing.${KNATIVE_EVENTING_VERSION}
 	  channel: alpha
 	EOF
-  if check_operatorgroups; then
-    cat <<-EOF | oc apply -f -
-	apiVersion: operators.coreos.com/v1alpha2
-	kind: OperatorGroup
-	metadata:
-	  name: knative-eventing
-	  namespace: knative-eventing
-	EOF
-  fi
 }

--- a/knative-operators.catalogsource.yaml
+++ b/knative-operators.catalogsource.yaml
@@ -756,6 +756,8 @@ data:
       kind: ClusterServiceVersion
       metadata:
         name: knative-build.v0.2.0
+        annotations:
+          alm-examples: '[{"apiVersion":"build.knative.dev/v1alpha1","kind":"Build","metadata":{"name":"sample-build"},"spec":{"source":{"git":{"url":"https://github.com/knative/build.git","revision":"master"}},"steps":[{"image":"fedora","args":["cat", "README.md"]}]}}]'
       spec:
         displayName: Knative Build
         description: |
@@ -771,7 +773,7 @@ data:
           type: SingleNamespace
         - supported: false
           type: MultiNamespace
-        - supported: false
+        - supported: true
           type: AllNamespaces
 
         install:
@@ -1171,7 +1173,7 @@ data:
           type: SingleNamespace
         - supported: false
           type: MultiNamespace
-        - supported: false
+        - supported: true
           type: AllNamespaces
 
         install:
@@ -2306,7 +2308,7 @@ data:
           type: SingleNamespace
         - supported: false
           type: MultiNamespace
-        - supported: false
+        - supported: true
           type: AllNamespaces
 
         install:

--- a/knative-operators.catalogsource.yaml
+++ b/knative-operators.catalogsource.yaml
@@ -756,9 +756,6 @@ data:
       kind: ClusterServiceVersion
       metadata:
         name: knative-build.v0.2.0
-        annotations:
-          olm.operatorGroup: knative-build
-          olm.operatorNamespace: knative-build
       spec:
         displayName: Knative Build
         description: |
@@ -772,9 +769,9 @@ data:
           type: OwnNamespace
         - supported: true
           type: SingleNamespace
-        - supported: true
+        - supported: false
           type: MultiNamespace
-        - supported: true
+        - supported: false
           type: AllNamespaces
 
         install:
@@ -959,6 +956,27 @@ data:
               kind: Build
               name: builds.build.knative.dev
               version: v1alpha1
+              statusDescriptors:
+                - description: The Pod this Build ran on
+                  displayName: Build Pod
+                  path: cluster.podName
+                  x-descriptors:
+                    - 'urn:alm:descriptor:io.kubernetes:Pod'
+                - description: The start time of the Build
+                  displayName: Start Time
+                  path: startTime
+                  x-descriptors:
+                    - 'urn:alm:descriptor:text'
+                - description: The completion time of the Build
+                  displayName: Completion Time
+                  path: completionTime
+                  x-descriptors:
+                    - 'urn:alm:descriptor:text'
+                - description: The conditions of this Build
+                  displayName: Conditions
+                  path: conditions
+                  x-descriptors:
+                    - 'urn:alm:descriptor:io.kubernetes.conditions'
             - description: Encapsulates a configurable, reusable build process
               displayName: Build Template
               kind: BuildTemplate
@@ -1138,9 +1156,6 @@ data:
       kind: ClusterServiceVersion
       metadata:
         name: knative-eventing.v0.2.1
-        annotations:
-          olm.operatorGroup: knative-eventing
-          olm.operatorNamespace: knative-eventing
       spec:
         displayName: Knative Eventing
         description: |
@@ -1154,9 +1169,9 @@ data:
           type: OwnNamespace
         - supported: true
           type: SingleNamespace
-        - supported: true
+        - supported: false
           type: MultiNamespace
-        - supported: true
+        - supported: false
           type: AllNamespaces
 
         install:
@@ -2276,9 +2291,6 @@ data:
       kind: ClusterServiceVersion
       metadata:
         name: knative-serving.v0.2.2
-        annotations:
-          olm.operatorGroup: knative-serving
-          olm.operatorNamespace: knative-serving
       spec:
         displayName: Knative Serving
         description: |
@@ -2292,9 +2304,9 @@ data:
           type: OwnNamespace
         - supported: true
           type: SingleNamespace
-        - supported: true
+        - supported: false
           type: MultiNamespace
-        - supported: true
+        - supported: false
           type: AllNamespaces
 
         install:
@@ -2606,6 +2618,17 @@ data:
               description: "Maintains the desired state for your deployment. It provides a clean separation between code and configuration and follows the Twelve-Factor App methodology. Modifying a configuration creates a new revision."
               displayName: Configuration
               version: v1alpha1
+              statusDescriptors:
+                - description: The latest Revision for this Configuration
+                  displayName: Latest Revision
+                  path: latestCreatedRevisionName
+                  x-descriptors:
+                    - 'urn:alm:descriptor:text'
+                - description: The conditions of this Configuration
+                  displayName: Conditions
+                  path: conditions
+                  x-descriptors:
+                    - 'urn:alm:descriptor:io.kubernetes.conditions'
             - kind: Revision
               name: revisions.serving.knative.dev
               description: "A point-in-time snapshot of the code and configuration for each modification made to the workload. Revisions are immutable objects and can be retained for as long as useful."
@@ -2621,6 +2644,27 @@ data:
               description: "Automatically manages the whole lifecycle of your workload. It controls the creation of other objects to ensure that your app has a route, a configuration, and a new revision for each update of the service. Service can be defined to always route traffic to the latest revision or to a pinned revision."
               displayName: Knative Service
               version: v1alpha1
+              statusDescriptors:
+                - description: The external domain name for this Service
+                  displayName: External Domain
+                  path: domain
+                  x-descriptors:
+                    - 'urn:alm:descriptor:text'
+                - description: The in-cluster domain name for this Service
+                  displayName: Internal Domain
+                  path: address.hostname
+                  x-descriptors:
+                    - 'urn:alm:descriptor:text'
+                - description: The latest Revision for this Service
+                  displayName: Latest Revision
+                  path: latestCreatedRevisionName
+                  x-descriptors:
+                    - 'urn:alm:descriptor:text'
+                - description: The conditions of this Service
+                  displayName: Conditions
+                  path: conditions
+                  x-descriptors:
+                    - 'urn:alm:descriptor:io.kubernetes.conditions'
             - description: A cached build image?
               displayName: Image
               kind: Image

--- a/maistra-operators.catalogsource.yaml
+++ b/maistra-operators.catalogsource.yaml
@@ -23,9 +23,6 @@ data:
       kind: ClusterServiceVersion
       metadata:
         name: maistra.v0.5.0
-        annotations:
-          olm.operatorGroup: istio-operator
-          olm.operatorNamespace: istio-operator
       spec:
         displayName: Maistra
         description: "Maistra, otherwise known as OpenShift Service Mesh, is Red Hat's version of Istio."
@@ -43,9 +40,9 @@ data:
           type: OwnNamespace
         - supported: true
           type: SingleNamespace
-        - supported: true
+        - supported: false
           type: MultiNamespace
-        - supported: true
+        - supported: false
           type: AllNamespaces
         install:
           strategy: deployment

--- a/maistra-operators.catalogsource.yaml
+++ b/maistra-operators.catalogsource.yaml
@@ -42,7 +42,7 @@ data:
           type: SingleNamespace
         - supported: false
           type: MultiNamespace
-        - supported: false
+        - supported: true
           type: AllNamespaces
         install:
           strategy: deployment

--- a/olm-catalog/knative-build.v0.2.0.clusterserviceversion.yaml
+++ b/olm-catalog/knative-build.v0.2.0.clusterserviceversion.yaml
@@ -2,6 +2,8 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   name: knative-build.v0.2.0
+  annotations:
+    alm-examples: '[{"apiVersion":"build.knative.dev/v1alpha1","kind":"Build","metadata":{"name":"sample-build"},"spec":{"source":{"git":{"url":"https://github.com/knative/build.git","revision":"master"}},"steps":[{"image":"fedora","args":["cat", "README.md"]}]}}]'
 spec:
   displayName: Knative Build
   description: |
@@ -17,7 +19,7 @@ spec:
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
-  - supported: false
+  - supported: true
     type: AllNamespaces
 
   install:

--- a/olm-catalog/knative-build.v0.2.0.clusterserviceversion.yaml
+++ b/olm-catalog/knative-build.v0.2.0.clusterserviceversion.yaml
@@ -2,9 +2,6 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   name: knative-build.v0.2.0
-  annotations:
-    olm.operatorGroup: knative-build
-    olm.operatorNamespace: knative-build
 spec:
   displayName: Knative Build
   description: |
@@ -18,9 +15,9 @@ spec:
     type: OwnNamespace
   - supported: true
     type: SingleNamespace
-  - supported: true
+  - supported: false
     type: MultiNamespace
-  - supported: true
+  - supported: false
     type: AllNamespaces
 
   install:
@@ -205,6 +202,27 @@ spec:
         kind: Build
         name: builds.build.knative.dev
         version: v1alpha1
+        statusDescriptors:
+          - description: The Pod this Build ran on
+            displayName: Build Pod
+            path: cluster.podName
+            x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes:Pod'
+          - description: The start time of the Build
+            displayName: Start Time
+            path: startTime
+            x-descriptors:
+              - 'urn:alm:descriptor:text'
+          - description: The completion time of the Build
+            displayName: Completion Time
+            path: completionTime
+            x-descriptors:
+              - 'urn:alm:descriptor:text'
+          - description: The conditions of this Build
+            displayName: Conditions
+            path: conditions
+            x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes.conditions'
       - description: Encapsulates a configurable, reusable build process
         displayName: Build Template
         kind: BuildTemplate

--- a/olm-catalog/knative-eventing.v0.2.1.clusterserviceversion.yaml
+++ b/olm-catalog/knative-eventing.v0.2.1.clusterserviceversion.yaml
@@ -2,9 +2,6 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   name: knative-eventing.v0.2.1
-  annotations:
-    olm.operatorGroup: knative-eventing
-    olm.operatorNamespace: knative-eventing
 spec:
   displayName: Knative Eventing
   description: |
@@ -18,9 +15,9 @@ spec:
     type: OwnNamespace
   - supported: true
     type: SingleNamespace
-  - supported: true
+  - supported: false
     type: MultiNamespace
-  - supported: true
+  - supported: false
     type: AllNamespaces
 
   install:

--- a/olm-catalog/knative-eventing.v0.2.1.clusterserviceversion.yaml
+++ b/olm-catalog/knative-eventing.v0.2.1.clusterserviceversion.yaml
@@ -17,7 +17,7 @@ spec:
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
-  - supported: false
+  - supported: true
     type: AllNamespaces
 
   install:

--- a/olm-catalog/knative-serving.v0.2.2.clusterserviceversion.yaml
+++ b/olm-catalog/knative-serving.v0.2.2.clusterserviceversion.yaml
@@ -17,7 +17,7 @@ spec:
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
-  - supported: false
+  - supported: true
     type: AllNamespaces
 
   install:

--- a/olm-catalog/knative-serving.v0.2.2.clusterserviceversion.yaml
+++ b/olm-catalog/knative-serving.v0.2.2.clusterserviceversion.yaml
@@ -2,9 +2,6 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   name: knative-serving.v0.2.2
-  annotations:
-    olm.operatorGroup: knative-serving
-    olm.operatorNamespace: knative-serving
 spec:
   displayName: Knative Serving
   description: |
@@ -18,9 +15,9 @@ spec:
     type: OwnNamespace
   - supported: true
     type: SingleNamespace
-  - supported: true
+  - supported: false
     type: MultiNamespace
-  - supported: true
+  - supported: false
     type: AllNamespaces
 
   install:
@@ -332,6 +329,17 @@ spec:
         description: "Maintains the desired state for your deployment. It provides a clean separation between code and configuration and follows the Twelve-Factor App methodology. Modifying a configuration creates a new revision."
         displayName: Configuration
         version: v1alpha1
+        statusDescriptors:
+          - description: The latest Revision for this Configuration
+            displayName: Latest Revision
+            path: latestCreatedRevisionName
+            x-descriptors:
+              - 'urn:alm:descriptor:text'
+          - description: The conditions of this Configuration
+            displayName: Conditions
+            path: conditions
+            x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes.conditions'
       - kind: Revision
         name: revisions.serving.knative.dev
         description: "A point-in-time snapshot of the code and configuration for each modification made to the workload. Revisions are immutable objects and can be retained for as long as useful."
@@ -347,6 +355,27 @@ spec:
         description: "Automatically manages the whole lifecycle of your workload. It controls the creation of other objects to ensure that your app has a route, a configuration, and a new revision for each update of the service. Service can be defined to always route traffic to the latest revision or to a pinned revision."
         displayName: Knative Service
         version: v1alpha1
+        statusDescriptors:
+          - description: The external domain name for this Service
+            displayName: External Domain
+            path: domain
+            x-descriptors:
+              - 'urn:alm:descriptor:text'
+          - description: The in-cluster domain name for this Service
+            displayName: Internal Domain
+            path: address.hostname
+            x-descriptors:
+              - 'urn:alm:descriptor:text'
+          - description: The latest Revision for this Service
+            displayName: Latest Revision
+            path: latestCreatedRevisionName
+            x-descriptors:
+              - 'urn:alm:descriptor:text'
+          - description: The conditions of this Service
+            displayName: Conditions
+            path: conditions
+            x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes.conditions'
       - description: A cached build image?
         displayName: Image
         kind: Image


### PR DESCRIPTION
Create OperatorGroups for each Operator before we create the
Subscription for that Operator. It does eventually work doing it the
other way around but this gets things started faster.

Those OperatorGroups specify a single target namespace that exactly
matches the namespace each component gets installed into.

Remove the olm.* annotations from the ClusterServiceVersions - these
are meant to be set by OLM and weren't only because we weren't using
OLM quite right for our scenario.

Add a few StatusDescriptors for some of our custom resources so the
user gets a bit more information when browsing them via the web
console.