### PR TITLE
Extra RBAC rules for knative 0.3.0 to run on OpenShift

### DIFF
--- a/knative-operators.catalogsource.yaml
+++ b/knative-operators.catalogsource.yaml
@@ -1127,15 +1127,138 @@ data:
             - serviceAccountName: build-controller
               rules:
               - apiGroups:
+                - ""
+                resources:
+                - pods
+                - namespaces
+                - secrets
+                - events
+                - serviceaccounts
+                - configmaps
+                - services
+                verbs:
+                - get
+                - list
+                - create
+                - update
+                - delete
+                - patch
+                - watch
+              - apiGroups:
+                - extensions
+                resources:
+                - deployments
+                verbs:
+                - get
+                - list
+                - create
+                - update
+                - delete
+                - patch
+                - watch
+              - apiGroups:
+                - admissionregistration.k8s.io
+                resources:
+                - mutatingwebhookconfigurations
+                verbs:
+                - get
+                - list
+                - create
+                - update
+                - delete
+                - patch
+                - watch
+              - apiGroups:
+                - apiextensions.k8s.io
+                resources:
+                - customresourcedefinitions
+                verbs:
+                - get
+                - list
+                - create
+                - update
+                - delete
+                - patch
+                - watch
+              - apiGroups:
+                - build.knative.dev
+                resources:
+                - builds
+                - buildtemplates
+                - clusterbuildtemplates
+                verbs:
+                - get
+                - list
+                - create
+                - update
+                - delete
+                - patch
+                - watch
+              - apiGroups:
+                - build.knative.dev
+                resources:
+                - builds/status
+                - buildtemplates/status
+                - clusterbuildtemplates/status
+                verbs:
+                - get
+                - list
+                - create
+                - update
+                - delete
+                - patch
+                - watch
+              - apiGroups:
+                - caching.internal.knative.dev
+                resources:
+                - images
+                verbs:
+                - get
+                - list
+                - create
+                - update
+                - delete
+                - deletecollection
+                - patch
+                - watch
+              - apiGroups:
+                - policy
+                resourceNames:
+                - knative-build
+                resources:
+                - podsecuritypolicies
+                verbs:
+                - use
+
+              # The above rules are from upstream. The remaining are
+              # required for OpenShift
+
+              - apiGroups:
+                - security.openshift.io
+                resources:
+                - securitycontextconstraints
+                verbs:
+                - use
+                resourceNames:
+                - privileged
+                - anyuid
+              - apiGroups:
                 - '*'
                 resources:
-                - '*'
+                - '*/finalizers'
                 verbs:
-                - '*'
-              - nonResourceURLs:
-                - '*'
+                - get
+                - list
+                - create
+                - update
+              - apiGroups:
+                - policy
+                resources:
+                - podsecuritypolicies
                 verbs:
-                - '*'
+                - create
+                - patch
+                - get
 
             deployments:
             - name: build-controller
@@ -1657,7 +1780,7 @@ data:
               - apiGroups:
                 - eventing.knative.dev
                 resources:
-                - channels/finalizers
+                - '*/finalizers'
                 verbs:
                 - update
               - apiGroups:
@@ -1712,6 +1835,18 @@ data:
                 - get
                 - list
                 - watch
+
+              # The above rules are from upstream. The remaining are
+              # required for OpenShift
+
+              - apiGroups:
+                - security.openshift.io
+                resources:
+                - securitycontextconstraints
+                verbs:
+                - use
+                resourceNames:
+                - privileged
 
             deployments:
             - name: eventing-controller
@@ -3237,15 +3372,201 @@ data:
             - serviceAccountName: controller
               rules:
               - apiGroups:
+                - ""
+                resources:
+                - pods
+                - namespaces
+                - secrets
+                - configmaps
+                - endpoints
+                - services
+                - events
+                - serviceaccounts
+                verbs:
+                - get
+                - list
+                - create
+                - update
+                - delete
+                - patch
+                - watch
+              - apiGroups:
+                - extensions
+                resources:
+                - ingresses
+                - deployments
+                verbs:
+                - get
+                - list
+                - create
+                - update
+                - delete
+                - patch
+                - watch
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                - deployments/scale
+                - statefulsets
+                verbs:
+                - get
+                - list
+                - create
+                - update
+                - delete
+                - patch
+                - watch
+              - apiGroups:
+                - admissionregistration.k8s.io
+                resources:
+                - mutatingwebhookconfigurations
+                verbs:
+                - get
+                - list
+                - create
+                - update
+                - delete
+                - patch
+                - watch
+              - apiGroups:
+                - apiextensions.k8s.io
+                resources:
+                - customresourcedefinitions
+                verbs:
+                - get
+                - list
+                - create
+                - update
+                - delete
+                - patch
+                - watch
+              - apiGroups:
+                - serving.knative.dev
+                resources:
+                - configurations
+                - routes
+                - revisions
+                - services
+                verbs:
+                - get
+                - list
+                - create
+                - update
+                - delete
+                - patch
+                - watch
+              - apiGroups:
+                - serving.knative.dev
+                resources:
+                - configurations/status
+                - routes/status
+                - revisions/status
+                - services/status
+                verbs:
+                - get
+                - list
+                - create
+                - update
+                - delete
+                - patch
+                - watch
+              - apiGroups:
+                - autoscaling.internal.knative.dev
+                resources:
+                - podautoscalers
+                - podautoscalers/status
+                verbs:
+                - get
+                - list
+                - create
+                - update
+                - delete
+                - patch
+                - watch
+              - apiGroups:
+                - autoscaling
+                resources:
+                - horizontalpodautoscalers
+                verbs:
+                - get
+                - list
+                - create
+                - update
+                - delete
+                - patch
+                - watch
+              - apiGroups:
+                - caching.internal.knative.dev
+                resources:
+                - images
+                verbs:
+                - get
+                - list
+                - create
+                - update
+                - delete
+                - patch
+                - watch
+              - apiGroups:
+                - networking.internal.knative.dev
+                resources:
+                - clusteringresses
+                - clusteringresses/status
+                verbs:
+                - get
+                - list
+                - create
+                - update
+                - delete
+                - patch
+                - watch
+              - apiGroups:
+                - build.knative.dev
+                resources:
+                - builds
+                verbs:
+                - get
+                - list
+                - create
+                - update
+                - delete
+                - patch
+                - watch
+              - apiGroups:
+                - networking.istio.io
+                resources:
+                - virtualservices
+                verbs:
+                - get
+                - list
+                - create
+                - update
+                - delete
+                - patch
+                - watch
+
+              # The above rules are from upstream. The remaining are
+              # required for OpenShift
+
+              - apiGroups:
+                - security.openshift.io
+                resources:
+                - securitycontextconstraints
+                verbs:
+                - use
+                resourceNames:
+                - privileged
+                - anyuid
+              - apiGroups:
                 - '*'
                 resources:
-                - '*'
+                - '*/finalizers'
                 verbs:
-                - '*'
-              - nonResourceURLs:
-                - '*'
-                verbs:
-                - '*'
+                - get
+                - list
+                - create
+                - update
 
             deployments:
             - name: activator

--- a/knative-operators.catalogsource.yaml
+++ b/knative-operators.catalogsource.yaml
@@ -1243,13 +1243,16 @@ data:
                 - privileged
                 - anyuid
               - apiGroups:
-                - '*'
+                - extensions
+                resources:
+                - deployments/finalizers
+                verbs:
+                - update
+              - apiGroups:
+                - build.knative.dev
                 resources:
                 - '*/finalizers'
                 verbs:
-                - get
-                - list
-                - create
                 - update
               - apiGroups:
                 - policy
@@ -3559,13 +3562,17 @@ data:
                 - privileged
                 - anyuid
               - apiGroups:
-                - '*'
+                - extensions
+                resources:
+                - deployments/finalizers
+                verbs:
+                - update
+              - apiGroups:
+                - serving.knative.dev
+                - networking.internal.knative.dev
                 resources:
                 - '*/finalizers'
                 verbs:
-                - get
-                - list
-                - create
                 - update
 
             deployments:

--- a/olm-catalog/knative-build.v0.3.0.clusterserviceversion.yaml
+++ b/olm-catalog/knative-build.v0.3.0.clusterserviceversion.yaml
@@ -37,6 +37,7 @@ spec:
           - events
           - serviceaccounts
           - configmaps
+          - services
           verbs:
           - get
           - list
@@ -130,6 +131,36 @@ spec:
           - podsecuritypolicies
           verbs:
           - use
+
+        # The above rules are from upstream. The remaining are
+        # required for OpenShift
+
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
+          resourceNames:
+          - privileged
+          - anyuid
+        - apiGroups:
+          - '*'
+          resources:
+          - '*/finalizers'
+          verbs:
+          - get
+          - list
+          - create
+          - update
+        - apiGroups:
+          - policy
+          resources:
+          - podsecuritypolicies
+          verbs:
+          - create
+          - patch
+          - get
 
       deployments:
       - name: build-controller

--- a/olm-catalog/knative-build.v0.3.0.clusterserviceversion.yaml
+++ b/olm-catalog/knative-build.v0.3.0.clusterserviceversion.yaml
@@ -29,15 +29,107 @@ spec:
       - serviceAccountName: build-controller
         rules:
         - apiGroups:
-          - '*'
+          - ""
           resources:
-          - '*'
+          - pods
+          - namespaces
+          - secrets
+          - events
+          - serviceaccounts
+          - configmaps
           verbs:
-          - '*'
-        - nonResourceURLs:
-          - '*'
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - patch
+          - watch
+        - apiGroups:
+          - extensions
+          resources:
+          - deployments
           verbs:
-          - '*'
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - patch
+          - watch
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - mutatingwebhookconfigurations
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - patch
+          - watch
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - patch
+          - watch
+        - apiGroups:
+          - build.knative.dev
+          resources:
+          - builds
+          - buildtemplates
+          - clusterbuildtemplates
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - patch
+          - watch
+        - apiGroups:
+          - build.knative.dev
+          resources:
+          - builds/status
+          - buildtemplates/status
+          - clusterbuildtemplates/status
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - patch
+          - watch
+        - apiGroups:
+          - caching.internal.knative.dev
+          resources:
+          - images
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - deletecollection
+          - patch
+          - watch
+        - apiGroups:
+          - policy
+          resourceNames:
+          - knative-build
+          resources:
+          - podsecuritypolicies
+          verbs:
+          - use
 
       deployments:
       - name: build-controller

--- a/olm-catalog/knative-build.v0.3.0.clusterserviceversion.yaml
+++ b/olm-catalog/knative-build.v0.3.0.clusterserviceversion.yaml
@@ -145,13 +145,16 @@ spec:
           - privileged
           - anyuid
         - apiGroups:
-          - '*'
+          - extensions
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - build.knative.dev
           resources:
           - '*/finalizers'
           verbs:
-          - get
-          - list
-          - create
           - update
         - apiGroups:
           - policy

--- a/olm-catalog/knative-eventing.v0.3.0.clusterserviceversion.yaml
+++ b/olm-catalog/knative-eventing.v0.3.0.clusterserviceversion.yaml
@@ -64,7 +64,7 @@ spec:
         - apiGroups:
           - eventing.knative.dev
           resources:
-          - channels/finalizers
+          - '*/finalizers'
           verbs:
           - update
         - apiGroups:
@@ -119,6 +119,18 @@ spec:
           - get
           - list
           - watch
+
+        # The above rules are from upstream. The remaining are
+        # required for OpenShift
+
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
+          resourceNames:
+          - privileged
 
       deployments:
       - name: eventing-controller

--- a/olm-catalog/knative-serving.v0.3.0.clusterserviceversion.yaml
+++ b/olm-catalog/knative-serving.v0.3.0.clusterserviceversion.yaml
@@ -27,15 +27,179 @@ spec:
       - serviceAccountName: controller
         rules:
         - apiGroups:
-          - '*'
+          - ""
           resources:
-          - '*'
+          - pods
+          - namespaces
+          - secrets
+          - configmaps
+          - endpoints
+          - services
+          - events
+          - serviceaccounts
           verbs:
-          - '*'
-        - nonResourceURLs:
-          - '*'
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - patch
+          - watch
+        - apiGroups:
+          - extensions
+          resources:
+          - ingresses
+          - deployments
           verbs:
-          - '*'
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - patch
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - deployments/scale
+          - statefulsets
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - patch
+          - watch
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - mutatingwebhookconfigurations
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - patch
+          - watch
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - patch
+          - watch
+        - apiGroups:
+          - serving.knative.dev
+          resources:
+          - configurations
+          - routes
+          - revisions
+          - services
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - patch
+          - watch
+        - apiGroups:
+          - serving.knative.dev
+          resources:
+          - configurations/status
+          - routes/status
+          - revisions/status
+          - services/status
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - patch
+          - watch
+        - apiGroups:
+          - autoscaling.internal.knative.dev
+          resources:
+          - podautoscalers
+          - podautoscalers/status
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - patch
+          - watch
+        - apiGroups:
+          - autoscaling
+          resources:
+          - horizontalpodautoscalers
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - patch
+          - watch
+        - apiGroups:
+          - caching.internal.knative.dev
+          resources:
+          - images
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - patch
+          - watch
+        - apiGroups:
+          - networking.internal.knative.dev
+          resources:
+          - clusteringresses
+          - clusteringresses/status
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - patch
+          - watch
+        - apiGroups:
+          - build.knative.dev
+          resources:
+          - builds
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - patch
+          - watch
+        - apiGroups:
+          - networking.istio.io
+          resources:
+          - virtualservices
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - patch
+          - watch
 
       deployments:
       - name: activator

--- a/olm-catalog/knative-serving.v0.3.0.clusterserviceversion.yaml
+++ b/olm-catalog/knative-serving.v0.3.0.clusterserviceversion.yaml
@@ -214,13 +214,17 @@ spec:
           - privileged
           - anyuid
         - apiGroups:
-          - '*'
+          - extensions
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - serving.knative.dev
+          - networking.internal.knative.dev
           resources:
           - '*/finalizers'
           verbs:
-          - get
-          - list
-          - create
           - update
 
       deployments:

--- a/olm-catalog/knative-serving.v0.3.0.clusterserviceversion.yaml
+++ b/olm-catalog/knative-serving.v0.3.0.clusterserviceversion.yaml
@@ -201,6 +201,28 @@ spec:
           - patch
           - watch
 
+        # The above rules are from upstream. The remaining are
+        # required for OpenShift
+
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
+          resourceNames:
+          - privileged
+          - anyuid
+        - apiGroups:
+          - '*'
+          resources:
+          - '*/finalizers'
+          verbs:
+          - get
+          - list
+          - create
+          - update
+
       deployments:
       - name: activator
         spec:


### PR DESCRIPTION
Our previous CSV's just used `cluster-admin` privs, which is gross. 