### PR TITLE
Install our knative operators on minikube

### DIFF
--- a/etc/scripts/install-on-minikube.sh
+++ b/etc/scripts/install-on-minikube.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# WARNING: this totally destroys and recreates your `knative` profile,
+# thereby guaranteeing (hopefully) a clean environment upon successful
+# completion.
+
+if minikube status | grep "host: Running" >/dev/null; then
+  echo "Please stop your running minikube to acknowledge this script will destroy it."
+  exit 1
+fi
+
+set -x
+
+# blow away everything in the knative profile
+minikube delete --profile knative
+
+# configure knative profile
+minikube profile knative
+minikube config set kubernetes-version v1.11.5 -p knative
+minikube config set memory 10240 -p knative
+minikube config set cpus 4 -p knative
+minikube config set disk-size 50g -p knative
+
+# Start minikube
+minikube start -p knative --extra-config=apiserver.enable-admission-plugins="LimitRanger,NamespaceExists,NamespaceLifecycle,ResourceQuota,ServiceAccount,DefaultStorageClass,MutatingAdmissionWebhook"
+
+#oc login -u admin -p admin
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+"$DIR/install.sh" -q

--- a/etc/scripts/install-on-minishift.sh
+++ b/etc/scripts/install-on-minishift.sh
@@ -4,22 +4,27 @@
 # thereby guaranteeing (hopefully) a clean environment upon successful
 # completion.
 
-if minishift status | grep "Minishift:  Running" >/dev/null; then
+if minishift status | head -1 | grep "Running" >/dev/null; then
   echo "Please stop your running minishift to acknowledge this script will destroy it."
   exit 1
 fi
 
 set -x
 
+OPENSHIFT_VERSION=${OPENSHIFT_VERSION:-v3.11.0}
+MEMORY=${MEMORY:-10GB}
+CPUS=${CPUS:-4}
+DISK_SIZE=${DISK_SIZE:-50g}
+
 # blow away everything in the knative profile
 minishift profile delete knative --force
 
 # configure knative profile
 minishift profile set knative
-minishift config set openshift-version v3.11.0
-minishift config set memory 10GB
-minishift config set cpus 4
-minishift config set disk-size 50g
+minishift config set openshift-version ${OPENSHIFT_VERSION}
+minishift config set memory ${MEMORY}
+minishift config set cpus ${CPUS}
+minishift config set disk-size ${DISK_SIZE}
 minishift config set image-caching true
 minishift addons enable admin-user
 

--- a/etc/scripts/install.sh
+++ b/etc/scripts/install.sh
@@ -7,7 +7,8 @@ if [ "$1" != "-q" ]; then
   echo "  This script will attempt to install istio, knative, and OLM in your "
   echo "  Kubernetes/OpenShift cluster."
   echo
-  echo "  A recent version of the `oc` CLI should be in your PATH"
+  echo "  If targeting OpenShift, a recent version of `oc` should be available"
+  echo "  in your PATH. Otherwise, `kubectl` will be used."
   echo
   echo "  If using OpenShift 3.11 and your cluster isn't minishift, ensure"
   echo "  \$KUBE_SSH_KEY and \$KUBE_SSH_USER are set"
@@ -37,9 +38,9 @@ wait_for_all_pods knative-serving
 # skip tag resolving for internal registry
 # OpenShift 3 and 4 place the registry in different locations, hence
 # the two hostnames here
-oc -n knative-serving get cm config-controller -oyaml | sed "s/\(^ *registriesSkippingTagResolving.*$\)/\1,docker-registry.default.svc:5000,image-registry.openshift-image-registry.svc:5000/" | oc apply -f -
+$CMD -n knative-serving get cm config-controller -oyaml | sed "s/\(^ *registriesSkippingTagResolving.*$\)/\1,docker-registry.default.svc:5000,image-registry.openshift-image-registry.svc:5000/" | oc apply -f -
 
-if oc get ns openshift 2>/dev/null; then
+if $CMD get ns openshift 2>/dev/null; then
   # Add Golang imagestreams to be able to build go based images
   oc import-image -n openshift golang --from=centos/go-toolset-7-centos7 --confirm
   oc import-image -n openshift golang:1.11 --from=centos/go-toolset-7-centos7 --confirm
@@ -51,9 +52,8 @@ if oc get ns openshift 2>/dev/null; then
   oc adm policy add-scc-to-user privileged -z default
   oc adm policy add-scc-to-user anyuid -z default
 else
-  oc create namespace myproject
-  oc project myproject
+  $CMD create namespace myproject
 fi
 
 # show all the running pods
-oc get pods --all-namespaces
+$CMD get pods --all-namespaces

--- a/etc/scripts/install.sh
+++ b/etc/scripts/install.sh
@@ -52,7 +52,6 @@ if oc get ns openshift 2>/dev/null; then
   oc adm policy add-scc-to-user anyuid -z default
 else
   oc create namespace myproject
-  oc label namespace myproject istio-injection=enabled
   oc project myproject
 fi
 

--- a/etc/scripts/install.sh
+++ b/etc/scripts/install.sh
@@ -1,16 +1,18 @@
 #!/usr/bin/env bash
 
-# Installs OLM first, and then istio and knative using OLM operators
+# Attempts to install istio, knative, and OLM, ideally not in that order.
 
 if [ "$1" != "-q" ]; then
   echo
-  echo "  WARNING: This script will blindly attempt to install OLM, istio, and knative"
-  echo "  on your OpenShift cluster, so if any are already there, hijinks may ensue."
+  echo "  This script will attempt to install istio, knative, and OLM in your "
+  echo "  Kubernetes/OpenShift cluster."
+  echo
+  echo "  A recent version of the `oc` CLI should be in your PATH"
   echo
   echo "  If using OpenShift 3.11 and your cluster isn't minishift, ensure"
   echo "  \$KUBE_SSH_KEY and \$KUBE_SSH_USER are set"
   echo
-  echo "  Pass -q to disable this warning"
+  echo "  Pass -q to disable this prompt"
   echo
   read -p "Enter to continue or Ctrl-C to exit: "
 fi
@@ -37,16 +39,22 @@ wait_for_all_pods knative-serving
 # the two hostnames here
 oc -n knative-serving get cm config-controller -oyaml | sed "s/\(^ *registriesSkippingTagResolving.*$\)/\1,docker-registry.default.svc:5000,image-registry.openshift-image-registry.svc:5000/" | oc apply -f -
 
-# Add Golang imagestreams to be able to build go based images
-oc import-image -n openshift golang --from=centos/go-toolset-7-centos7 --confirm
-oc import-image -n openshift golang:1.11 --from=centos/go-toolset-7-centos7 --confirm
+if oc get ns openshift 2>/dev/null; then
+  # Add Golang imagestreams to be able to build go based images
+  oc import-image -n openshift golang --from=centos/go-toolset-7-centos7 --confirm
+  oc import-image -n openshift golang:1.11 --from=centos/go-toolset-7-centos7 --confirm
 
-# these perms are required by istio
-if ! oc project myproject 2>/dev/null; then
-  oc new-project myproject
+  if ! oc project myproject 2>/dev/null; then
+    oc new-project myproject
+  fi
+  # these perms are required by istio
+  oc adm policy add-scc-to-user privileged -z default
+  oc adm policy add-scc-to-user anyuid -z default
+else
+  oc create namespace myproject
+  oc label namespace myproject istio-injection=enabled
+  oc project myproject
 fi
-oc adm policy add-scc-to-user privileged -z default
-oc adm policy add-scc-to-user anyuid -z default
 
-# show all the pods
+# show all the running pods
 oc get pods --all-namespaces

--- a/etc/scripts/install.sh
+++ b/etc/scripts/install.sh
@@ -7,8 +7,8 @@ if [ "$1" != "-q" ]; then
   echo "  This script will attempt to install istio, knative, and OLM in your "
   echo "  Kubernetes/OpenShift cluster."
   echo
-  echo "  If targeting OpenShift, a recent version of `oc` should be available"
-  echo "  in your PATH. Otherwise, `kubectl` will be used."
+  echo "  If targeting OpenShift, a recent version of 'oc' should be available"
+  echo "  in your PATH. Otherwise, 'kubectl' will be used."
   echo
   echo "  If using OpenShift 3.11 and your cluster isn't minishift, ensure"
   echo "  \$KUBE_SSH_KEY and \$KUBE_SSH_USER are set"

--- a/etc/scripts/installation-functions.sh
+++ b/etc/scripts/installation-functions.sh
@@ -49,9 +49,9 @@ function check_operatorgroups {
 
 function enable_admission_webhooks {
   if check_openshift_4; then
-    echo "Detected OpenShift 4 - skipping enabling admission webhooks."
+    echo "Detected OpenShift 4 - skipping enabling admission webhooks"
   elif check_minikube; then
-    echo "Detected minikube - skipping enabling admission webhooks."
+    echo "Detected minikube - assuming admission webhooks enabled via --extra-config"
   elif check_minishift; then
     echo "Detected minishift - checking if admission webhooks are enabled."
     if ! minishift openshift config view --target=kube | grep ValidatingAdmissionWebhook >/dev/null; then
@@ -165,7 +165,6 @@ function install_istio {
   if check_minikube; then
     echo "Detected minikube - incompatible with Maistra operator, so installing upstream istio."
     oc apply -f "https://github.com/knative/serving/releases/download/${KNATIVE_SERVING_VERSION}/istio.yaml"
-    oc label namespace default istio-injection=enabled
     wait_for_all_pods istio-system
   else
     oc create ns istio-operator

--- a/etc/scripts/installation-functions.sh
+++ b/etc/scripts/installation-functions.sh
@@ -177,6 +177,7 @@ function install_olm {
 function install_istio {
   if check_minikube; then
     echo "Detected minikube - incompatible with Maistra operator, so installing upstream istio."
+    $CMD apply -f "https://github.com/knative/serving/releases/download/${KNATIVE_SERVING_VERSION}/istio-crds.yaml" && \
     $CMD apply -f "https://github.com/knative/serving/releases/download/${KNATIVE_SERVING_VERSION}/istio.yaml"
     wait_for_all_pods istio-system
   else


### PR DESCRIPTION
We can't use the Maistra operator, since it's dependent on OpenShift,
so we install the istio.yaml released with knative-serving instead.

We do install OLM and the knative operators, of course.