### PR TITLE
give knative-eventing-operator sa cluster-admin

### DIFF
--- a/etc/scripts/installation-functions.sh
+++ b/etc/scripts/installation-functions.sh
@@ -168,7 +168,7 @@ function install_olm {
     oc adm policy add-cluster-role-to-user cluster-admin system:serviceaccount:istio-operator:istio-operator
     oc adm policy add-cluster-role-to-user cluster-admin system:serviceaccount:knative-build:build-controller
     oc adm policy add-cluster-role-to-user cluster-admin system:serviceaccount:knative-serving:controller
-    oc adm policy add-cluster-role-to-user cluster-admin system:serviceaccount:knative-eventing:default
+    oc adm policy add-cluster-role-to-user cluster-admin system:serviceaccount:knative-eventing:knative-eventing-operator
   elif [ "$(olm_namespace)" = "" ]; then
     $CMD apply -f https://github.com/operator-framework/operator-lifecycle-manager/releases/download/0.9.0/olm.yaml
     wait_for_all_pods olm


### PR DESCRIPTION
After upgrade to release v0.5.0, the installer times-out waiting for the `eventing-controller` deployment. After further investigation, the operator seems to run under the `knative-eventing-operator` service account.

Example error in the Eventing operator pod logs, after current installer runs on a fresh minishift:
`clusterroles.rbac.authorization.k8s.io "addressable-resolver" is forbidden: must have cluster-admin privileges to use the aggregationRule"`

This change gives cluster-admin to the `knative-eventing-operator` service account.