### PR TITLE
Fix tag-to-digest config in installation script

### DIFF
--- a/etc/scripts/install.sh
+++ b/etc/scripts/install.sh
@@ -43,8 +43,8 @@ enable_interaction_with_registry
 
 # skip tag resolving for internal registry
 # OpenShift 3 and 4 place the registry in different locations, hence
-# the two hostnames here
-$CMD -n knative-serving get cm config-controller -oyaml | yq w - "data.registriesSkippingTagResolving" "ko.local,dev.local,docker-registry.default.svc:5000,image-registry.openshift-image-registry.svc:5000" | $CMD apply -f -
+# the additional two hostnames here
+$CMD patch configmap config-controller -n knative-serving --type merge -p '{"data":{"registriesSkippingTagResolving": "ko.local,dev.local,docker-registry.default.svc:5000,image-registry.openshift-image-registry.svc:5000"}}'
 
 if $CMD get ns openshift 2>/dev/null; then
   # Add Golang imagestreams to be able to build go based images

--- a/etc/scripts/install.sh
+++ b/etc/scripts/install.sh
@@ -44,7 +44,7 @@ enable_interaction_with_registry
 # skip tag resolving for internal registry
 # OpenShift 3 and 4 place the registry in different locations, hence
 # the two hostnames here
-$CMD -n knative-serving get cm config-controller -oyaml | sed "s/\(^ *registriesSkippingTagResolving.*$\)/\1,docker-registry.default.svc:5000,image-registry.openshift-image-registry.svc:5000/" | oc apply -f -
+$CMD -n knative-serving get cm config-controller -oyaml | yq w - "data.registriesSkippingTagResolving" "ko.local,dev.local,docker-registry.default.svc:5000,image-registry.openshift-image-registry.svc:5000" | $CMD apply -f -
 
 if $CMD get ns openshift 2>/dev/null; then
   # Add Golang imagestreams to be able to build go based images


### PR DESCRIPTION
Fixes https://github.com/openshift-cloud-functions/knative-operators/issues/35

The configmap `config-controller` of `knative-serving` namespace now has a different structure after the change done [here](https://github.com/knative/serving/commit/7401bce6ea5ca2d0ab43d25720bc52b5b9f9bbb8#diff-aeaefb1b63b460c864c182af57d1650cL35).

Previously, there was a `registriesSkippingTagResolving` entry in the configMap data but now that is removed. There's a `registriesSkippingTagResolving` occurrence in the `_example` key of the configMap data and currently that was what is modified with `sed`.

Current default config map: https://github.com/knative/serving/blob/v0.5.2/config/config-controller.yaml

Output before: https://gist.github.com/aliok/3a81066f05519b948e1edc894f6b7688
Output now: https://gist.github.com/aliok/7ceb5552a34d17855523b301fe6d9ec9

Notes:
* Change is backwards compatible. It overwrites the existing value of `data.registriesSkippingTagResolving`, which was available before https://github.com/knative/serving/commit/7401bce6ea5ca2d0ab43d25720bc52b5b9f9bbb8#diff-aeaefb1b63b460c864c182af57d1650cL35
~~* This PR depends on availability of `yq`. I think it is kind of hard to do this change with `sed`.~~
UPDATE: using `kubectl patch --type merge` now.